### PR TITLE
Make Freemail Compile Again

### DIFF
--- a/src/org/freenetproject/freemail/MailMessage.java
+++ b/src/org/freenetproject/freemail/MailMessage.java
@@ -659,7 +659,7 @@ public class MailMessage {
 			String[] charsetParts = parts[1].trim().split("=", 2);
 			if(!charsetParts[0].equalsIgnoreCase("charset")) {
 				throw new UnsupportedEncodingException("Can't handle text/plain with parameter other than charset. "
-						+ "Unrecognised parameters were: " + params);
+						+ "Unrecognised parameters were: " + charsetParts[0]);
 			}
 
 			String charsetName = charsetParts[1];


### PR DESCRIPTION
In the last merge (771f936) a variable was removed, but not all its usages were removed, resulting in a compile error. This fixes said error.